### PR TITLE
feat: make migrations dir configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ async function run() {
     const githubRefSplit = GITHUB_REF.split('/');
     const ENVIRONMENT_INPUT = githubRefSplit[githubRefSplit.length - 1];
 
-    const MIGRATIONS_DIR = process.env.GITHUB_WORKSPACE + "/migrations"
+    const DEFAULT_MIGRATIONS_DIR = 'migrations';
+    const MIGRATIONS_DIR = path.join(process.env.GITHUB_WORKSPACE, process.env.MIGRATIONS_DIR || DEFAULT_MIGRATIONS_DIR);
 
     const client = createClient({
       accessToken: MANAGEMENT_API_KEY


### PR DESCRIPTION
This PR makes the path to the migrations directory configurable, via the environment variable `MIGRATIONS_DIR`. The default directory is `migrations`, making this a backwards compatible change.

Also uses `path.join` to help ensure the path is normalized.