### PR TITLE
feat: add environment name and url as action outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,10 @@
 name: 'Contentful Migration Action'
 description: 'Run a Migration against your Contentful space'
+outputs:
+  environment-url:
+    description: 'Contenful enviornment URL'
+  environment-name:
+    description: 'Contentful environment name'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -185,6 +185,13 @@ async function run() {
       console.log('No alias changes required');
     }
 
+    const environmentUrl = `https://app.contentful.com/spaces/${space.sys.id}/environments/${ENVIRONMENT_ID}`
+    const environmentName = ENVIRONMENT_ID
+
+    core.debug(`Contentful environment url is ${environmentUrl}`)
+    core.debug(`Contentful environment name is ${environmentName}`)
+    core.setOutput('environment-url', environmentUrl)
+    core.setOutput('environment-name', environmentName)
     console.log('All done!');
   }
   catch (error) {


### PR DESCRIPTION
This PR adds the Contentful environment URL and name as outputs of the Action. For example, this could be used by subsequent Actions (or maybe an addition to this action? :) ) to create comments on commits and PRs, detailing the Contentful environment created by CI.