### PR TITLE
Add support for different "production" branch names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,10 @@
 name: 'Contentful Migration Action'
 description: 'Run a Migration against your Contentful space'
+inputs: 
+  main_branch:
+    description: 'The default "production" branch that contentful can consider to be the main or master branch.'
+    required: false
+    default: 'master'
 outputs:
   environment_url:
     description: 'Contentful environment URL'

--- a/index.js
+++ b/index.js
@@ -22,7 +22,10 @@ async function run() {
 
     const getBranchName = () => {
       let { ref } = context
-
+      
+      console.log('github.context.eventName', github.context.eventName)
+      
+      // if we are on a pull request return the branch name
       if (github.context.eventName === 'pull_request') {
         const pullRequestPayload = github.context.payload
         core.info(`head : ${pullRequestPayload.pull_request.head}`)
@@ -61,6 +64,8 @@ async function run() {
 
     let environment;
     console.log('Running with the following configuration');
+    console.log('ENVIRONMENT_INPUT is', ENVIRONMENT_INPUT);
+    console.log('main_branch is', mainBranch);
     // ---------------------------------------------------------------------------
     if (ENVIRONMENT_INPUT == mainBranch) {
       console.log(`Running on master.`);

--- a/index.js
+++ b/index.js
@@ -23,8 +23,6 @@ async function run() {
     const getBranchName = () => {
       let { ref } = context
       
-      console.log('github.context.eventName', github.context.eventName)
-      
       // if we are on a pull request return the branch name
       if (github.context.eventName === 'pull_request') {
         const pullRequestPayload = github.context.payload
@@ -64,8 +62,7 @@ async function run() {
 
     let environment;
     console.log('Running with the following configuration');
-    console.log('ENVIRONMENT_INPUT is', ENVIRONMENT_INPUT);
-    console.log('main_branch is', mainBranch);
+
     // ---------------------------------------------------------------------------
     if (ENVIRONMENT_INPUT == mainBranch) {
       console.log(`Running on master.`);
@@ -198,7 +195,7 @@ async function run() {
 
     // ---------------------------------------------------------------------------
     console.log('Checking if we need to update master alias');
-    if (ENVIRONMENT_INPUT == 'master') {
+    if (ENVIRONMENT_INPUT == mainBranch) {
       console.log(`Running on master.`);
       console.log(`Updating master alias.`);
       await space.getEnvironmentAlias('master')


### PR DESCRIPTION
With the recent addition of changes to branch name conventions (e.g main instead of master) this action should have an option to change the production branch.

**The problem**
If you are like me and have renamed the "master" branch to "main" this action will in its current state only interpret the main branch as a feature branch and so no use the migration workflow intended for production.

**The changes that I've made are:**
1. Added an action input called `main_branch` which is not required, it defaults back to "master"
2. Changed certain if statements to instead see if the environment is equal to the `main_branch` input or its default instead of just "master"

This PR still needs to be tested a little bit more. I've yet to successfully tested it myself because for some reason my workflow where I use `patrickedqvist/contentful-action@main` doesn't seem to run. Maybe it's just a simple miss. 